### PR TITLE
Refactor NPM Published Artifacts

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -7,13 +7,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: yarn install --frozen-lockfile
-    - run: yarn build:asc
-    - run: yarn publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn install --frozen-lockfile
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -80,7 +80,6 @@ typings/
 
 # Nuxt.js build / generate output
 .nuxt
-dist
 
 # Gatsby files
 .cache/

--- a/.npmignore
+++ b/.npmignore
@@ -103,4 +103,17 @@ dist
 # TernJS port file
 .tern-port
 
-/build
+# Don't publish the source
+src/
+
+# Config files we don't need
+.github
+.vscode
+.prettierrc
+.eslintignore
+.eslintrc.json
+.gitignore
+.mocharc.json
+jest.config.json
+nyc.config.json
+tsconfig.json

--- a/.npmignore
+++ b/.npmignore
@@ -114,6 +114,7 @@ src/
 .eslintrc.json
 .gitignore
 .mocharc.json
+asconfig.json
 jest.config.json
 nyc.config.json
 tsconfig.json

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ npm publish
 yarn publish
 ```
 
-### Via github CI
+### Via GitHub CI
 
-1. Push any changes to github
+1. Push any changes to GitHub
 2. Create a new release version with `yarn version`
-3. It will tag and push to Github which will trigger the CI to publish to NPM
+3. It will tag and push to GitHub which will trigger the CI to publish to NPM

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The items in this library will allow you to interact with Estfor Kingdom via:
 
-- Vanilla JS applications
+- Vanilla JavaScript applications
 - React, Angular, and other front end frameworks
 - NodeJS / Typescript back end services
 - AssemblyScript / WebAssembly for use with [The Graph Protocol](https://github.com/graphprotocol/graph-node)'s web3 indexing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The items in this library will allow you to interact with Estfor Kingdom via:
 
 - Vanilla JavaScript applications
 - React, Angular, and other front end frameworks
-- NodeJS / Typescript back end services
+- NodeJS / TypeScript back end services
 - AssemblyScript / WebAssembly for use with [The Graph Protocol](https://github.com/graphprotocol/graph-node)'s web3 indexing
 
 [NPMJS Package](https://www.npmjs.com/package/@paintswap/estfor-definitions)

--- a/asconfig.json
+++ b/asconfig.json
@@ -8,11 +8,11 @@
   "targets": {
     "release": {
       "optimize": true,
-      "outFile": "build/index.wasm"
+      "outFile": "dist/index.wasm"
     },
     "debug": {
       "debug": true,
-      "outFile": "build/debug.wasm"
+      "outFile": "dist/debug.wasm"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
   "ascMain": "src/index.ts",
   "scripts": {
     "clean": "shx rm -rf ./dist",
-    "build": "yarn build:tsc && yarn build:asc && yarn build:mjs",
+    "build": "npm run build:tsc && npm run build:asc && npm run build:mjs",
     "build:asc": "asc --target release",
     "build:asc:debug": "asc --target debug",
     "build:tsc": "tsc",
     "build:mjs": "shx cp src/index.mjs dist/index.mjs",
-    "prepare": "yarn clean && yarn build",
+    "prepack": "npm run clean",
+    "prepare": "npm run build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paintswap/estfor-definitions",
-  "version": "1.0.90",
+  "version": "1.0.89",
   "description": "Types and constants for Estfor Kingdom",
   "repository": {
     "type": "git",
@@ -24,11 +24,12 @@
   "ascMain": "src/index.ts",
   "scripts": {
     "clean": "rm -rf ./dist",
-    "build": "yarn build:tsc",
-    "build:tsc": "tsc",
+    "build": "yarn build:tsc && yarn build:asc && yarn build:mjs",
     "build:asc": "asc --target release",
     "build:asc:debug": "asc --target debug",
-    "prepare": "yarn clean && yarn build:tsc && yarn build:asc && cp src/index.mjs dist/index.mjs",
+    "build:tsc": "tsc",
+    "build:mjs": "cp src/index.mjs dist/index.mjs",
+    "prepack": "yarn clean && yarn build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "build:asc:debug": "asc --target debug",
     "build:tsc": "tsc",
     "build:mjs": "shx cp src/index.mjs dist/index.mjs",
-    "postinstall": "yarn build",
-    "prepack": "yarn clean && yarn build",
+    "prepare": "yarn clean && yarn build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paintswap/estfor-definitions",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "description": "Types and constants for Estfor Kingdom",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,17 @@
     "web3",
     "thegraph"
   ],
-  "module": "src/index.mjs",
-  "ascMain": "src/index.ts",
+  "module": "dist/index.mjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "ascMain": "src/index.ts",
   "scripts": {
+    "clean": "rm -rf ./dist",
     "build": "yarn build:tsc",
     "build:tsc": "tsc",
     "build:asc": "asc --target release",
     "build:asc:debug": "asc --target debug",
-    "prepare": "yarn build",
+    "prepare": "yarn clean && yarn build:tsc && yarn build:asc && cp src/index.mjs dist/index.mjs",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:asc:debug": "asc --target debug",
     "build:tsc": "tsc",
     "build:mjs": "shx cp src/index.mjs dist/index.mjs",
-    "prepack": "npm run clean && npm run build",
+    "prepare": "npm run clean && npm run build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "types": "dist/index.d.ts",
   "ascMain": "src/index.ts",
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "shx rm -rf ./dist",
     "build": "yarn build:tsc && yarn build:asc && yarn build:mjs",
     "build:asc": "asc --target release",
     "build:asc:debug": "asc --target debug",
     "build:tsc": "tsc",
-    "build:mjs": "cp src/index.mjs dist/index.mjs",
+    "build:mjs": "shx cp src/index.mjs dist/index.mjs",
     "postinstall": "yarn build",
     "prepack": "yarn clean && yarn build",
     "version": "git add -A src",
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/PaintSwap/estfor-definitions",
   "devDependencies": {
     "assemblyscript": "0.19.23",
-    "run-script-os": "^1.1.6",
+    "shx": "^0.3.4",
     "typescript": "^5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,10 +40,8 @@
   },
   "homepage": "https://github.com/PaintSwap/estfor-definitions",
   "devDependencies": {
+    "assemblyscript": "0.19.23",
     "run-script-os": "^1.1.6",
-    "typescript": "^4.9.5"
-  },
-  "dependencies": {
-    "assemblyscript": "0.19.10"
+    "typescript": "^5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:asc:debug": "asc --target debug",
     "build:tsc": "tsc",
     "build:mjs": "shx cp src/index.mjs dist/index.mjs",
-    "prepare": "npm run clean && npm run build",
+    "prepack": "npm run clean && npm run build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   ],
   "module": "src/index.mjs",
   "ascMain": "src/index.ts",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "yarn build:tsc",
     "build:tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },
-  "author": "Paintswap Team",
+  "author": "PaintSwap Team",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/PaintSwap/estfor-definitions/issues"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "ascMain": "src/index.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./types": "./dist/types.js",
+    "./constants": "./dist/constants.js"
+  },
   "scripts": {
     "clean": "shx rm -rf ./dist",
     "build": "npm run build:tsc && npm run build:asc && npm run build:mjs",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "@paintswap/estfor-definitions",
   "version": "1.0.89",
   "description": "Types and constants for Estfor Kingdom",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/PaintSwap/estfor-definitions.git"
-  },
   "keywords": [
     "estfor",
     "estfor kingdom",
@@ -18,6 +14,16 @@
     "web3",
     "thegraph"
   ],
+  "author": "PaintSwap Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/PaintSwap/estfor-definitions/issues"
+  },
+  "homepage": "https://github.com/PaintSwap/estfor-definitions",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PaintSwap/estfor-definitions.git"
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -34,12 +40,6 @@
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },
-  "author": "PaintSwap Team",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/PaintSwap/estfor-definitions/issues"
-  },
-  "homepage": "https://github.com/PaintSwap/estfor-definitions",
   "devDependencies": {
     "assemblyscript": "0.19.23",
     "shx": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "build:asc:debug": "asc --target debug",
     "build:tsc": "tsc",
     "build:mjs": "shx cp src/index.mjs dist/index.mjs",
-    "prepack": "npm run clean",
-    "prepare": "npm run build",
+    "prepare": "npm run clean && npm run build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:asc:debug": "asc --target debug",
     "build:tsc": "tsc",
     "build:mjs": "cp src/index.mjs dist/index.mjs",
+    "postinstall": "yarn build",
     "prepack": "yarn clean && yarn build",
     "version": "git add -A src",
     "postversion": "git push && git push --tags"

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,5 +1,5 @@
-import { NONE } from '../constants.js'
-import * as EstforTypes from '../types.js'
-import * as EstforConstants from '../constants.js'
+import { NONE } from './constants.js'
+import * as EstforTypes from './types.js'
+import * as EstforConstants from './constants.js'
 
 export { EstforTypes, EstforConstants, NONE }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,5 +1,3 @@
-import { NONE } from './constants.js'
-import * as EstforTypes from './types.js'
-import * as EstforConstants from './constants.js'
-
-export { EstforTypes, EstforConstants, NONE }
+export { NONE } from './constants.js'
+export * as EstforTypes from './types.js'
+export * as EstforConstants from './constants.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -423,14 +423,14 @@ export class Player {
   boostStartTime: u64 = 0
   boostDuration: u32 = 0
   boostVal: u8 = 0
-  boostType: BoostType
+  boostType: BoostType = BoostType.NONE
   boostItemTokenId: u16 = 0
 
   /* Extra Boost */
   extraBoostStartTime: u64 = 0
   extraBoostDuration: u32 = 0
   extraBoostVal: u8 = 0
-  extraBoostType: BoostType
+  extraBoostType: BoostType = BoostType.NONE
   extraBoostItemTokenId: u16 = 0
 
   /* Socials */
@@ -904,7 +904,7 @@ export class Clan {
   boostStartTime: u64 = 0
   boostDuration: u32 = 0
   boostVal: u8 = 0
-  boostType: BoostType
+  boostType: BoostType = BoostType.NONE
   boostItemTokenId: u16 = 0
 
   totalDonated: string = '0'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "outDir": "./",
+    "outDir": "./dist"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,25 +11,154 @@ assemblyscript@0.19.23:
     long "^5.2.0"
     source-map-support "^0.5.20"
 
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
 binaryen@102.0.0-nightly.20211028:
   version "102.0.0-nightly.20211028"
   resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-102.0.0-nightly.20211028.tgz#8f1efb0920afd34509e342e37f84313ec936afb2"
   integrity sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w==
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
 
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+glob@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+hasown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
+  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  dependencies:
+    function-bind "^1.1.2"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+is-core-module@^2.13.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
+  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
+  dependencies:
+    hasown "^2.0.0"
+
 long@^5.2.0:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
-run-script-os@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
-  integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@^1.2.3:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
+
+resolve@^1.1.6:
+  version "1.22.8"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+  dependencies:
+    is-core-module "^2.13.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
+shx@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
+  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.5"
 
 source-map-support@^0.5.20:
   version "0.5.21"
@@ -44,7 +173,17 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,30 +2,49 @@
 # yarn lockfile v1
 
 
-assemblyscript@0.19.10:
-  version "0.19.10"
-  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.19.10.tgz#7ede6d99c797a219beb4fa4614c3eab9e6343c8e"
-  integrity sha512-HavcUBXB3mBTRGJcpvaQjmnmaqKHBGREjSPNsIvnAk2f9dj78y4BkMaSSdvBQYWcDDzsHQjyUC8stICFkD1Odg==
+assemblyscript@0.19.23:
+  version "0.19.23"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.19.23.tgz#16ece69f7f302161e2e736a0f6a474e6db72134c"
+  integrity sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==
   dependencies:
-    binaryen "101.0.0-nightly.20210723"
-    long "^4.0.0"
+    binaryen "102.0.0-nightly.20211028"
+    long "^5.2.0"
+    source-map-support "^0.5.20"
 
-binaryen@101.0.0-nightly.20210723:
-  version "101.0.0-nightly.20210723"
-  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-101.0.0-nightly.20210723.tgz#b6bb7f3501341727681a03866c0856500eec3740"
-  integrity sha512-eioJNqhHlkguVSbblHOtLqlhtC882SOEPKmNFZaDuz1hzQjolxZ+eu3/kaS10n3sGPONsIZsO7R9fR00UyhEUA==
+binaryen@102.0.0-nightly.20211028:
+  version "102.0.0-nightly.20211028"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-102.0.0-nightly.20211028.tgz#8f1efb0920afd34509e342e37f84313ec936afb2"
+  integrity sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w==
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+long@^5.2.0:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 run-script-os@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
   integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+source-map-support@^0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+typescript@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==


### PR DESCRIPTION
Update package to use files from ./dist and remove config from NPM deployment.

Add default NONE values.

Fix typos.

Update dependencies - TypeScript and AssemblyScript.

> ! `index.js`, `index.mjs`, `index.d.ts`, and `index.wasm` have moved to the `./dist` folder 